### PR TITLE
Make color inherit more important when deployed

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,10 +7,15 @@ const theme = createMuiTheme({
     overrides: {
         MuiGrid: {
             item: {
-                margin: '10px'
+                margin: '10px',
+            },
+        },
+        MuiButton: {
+            colorInherit: {
+                color: 'inherit !important' // Fix for clashing text colors when deployed
             }
-        }
-    }
+        },
+    },
 });
 
 export default responsiveFontSizes(theme);


### PR DESCRIPTION
- Material UI styles clash (prioritizes `MuiTypography-colorPrimary` instead of `MuiButton-colorInherit`