### PR TITLE
Fix build folder in github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,8 +41,8 @@ jobs:
             - name: Archive production artifacts
               uses: actions/upload-artifact@v2
               with:
-                  name: build
-                  path: build
+                  name: public
+                  path: public
 
     deploy:
         # The type of runner that the job will run on


### PR DESCRIPTION
- Build step targets the wrong folder to archive