### PR TITLE
Cache node_modules

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ on:
             - dev
     pull_request:
         branches:
-            - '**'
+            - dev
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
@@ -31,6 +31,18 @@ jobs:
               uses: actions/setup-node@v2.1.4
               with:
                   node-version: 12.x
+
+            - name: Cache node modules
+              uses: actions/cache@v2
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  path: ./node_modules
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-build-${{ env.cache-name }}-
+                      ${{ runner.os }}-build-
+                      ${{ runner.os }}-
 
             - name: Install dependencies
               run: npm install


### PR DESCRIPTION
If no changes to package-lock.json is made, cached `node_modules` will be used