### PR TITLE
Fix background clipping

### DIFF
--- a/src/components/Diagonals.css
+++ b/src/components/Diagonals.css
@@ -1,7 +1,7 @@
 .Diagonals {
     position: absolute;
-    width: 100vmax;
+    width: 100%;
 
-    top: -30vmax;
-    right: -40vmax;
+    top: -30%;
+    right: -20%;
 }

--- a/src/components/Diagonals.tsx
+++ b/src/components/Diagonals.tsx
@@ -7,16 +7,19 @@ const colors = ['#FF2525', '#FFB800', '#FF007A', '#0E8BFF', '#00FFA3', '#8DEF5F'
 
 function Diagonal({ index }: { index: number }) {
     const scale = 0.8 * Math.random() + 0.2;
+    const svgHeight = 1466;
+    const lineLength = 976;
+    const travelDistance = svgHeight - lineLength;
 
     useEffect(() => {
         // Need individual durations to make infinite loop
-        const initialPosition = Math.random() * 733 * 2 - 733;
+        const initialPosition = -lineLength / 2 - svgHeight / 2 + (Math.random() * lineLength) / 2;
         const lifetime = 30000 * (1 + Math.random());
         const transitionTime = 2000;
 
         anime({
             targets: `.diagonal${index}`,
-            translateY: [initialPosition, initialPosition + 800],
+            translateY: [initialPosition, initialPosition + travelDistance],
             loop: true,
             opacity: [
                 { value: 0, duration: 0 },

--- a/src/components/Diagonals.tsx
+++ b/src/components/Diagonals.tsx
@@ -50,7 +50,7 @@ function Diagonals() {
     const diagonals = 15;
 
     return (
-        <div className="background">
+        <div className="Background">
             <div className="Diagonals">
                 <svg width="100%" height="100%" viewBox="-733 0 1466 1466" fill="none" xmlns="http://www.w3.org/2000/svg">
                     {[...Array(diagonals).keys()].map((_, i) => (

--- a/src/components/Spirals.tsx
+++ b/src/components/Spirals.tsx
@@ -44,7 +44,7 @@ function Spirals() {
     }, []);
 
     return (
-        <div className="background">
+        <div className="Background">
             <div className="Spirals">
                 <svg width="100%" height="100%" viewBox="-654 -654 1308 1308" fill="none" xmlns="http://www.w3.org/2000/svg">
                     {[...Array(spirals).keys()].map((_, i) => (

--- a/src/gatsby-theme-material-ui-top-layout/theme.tsx
+++ b/src/gatsby-theme-material-ui-top-layout/theme.tsx
@@ -41,8 +41,8 @@ const theme = createMuiTheme({
                 color: '#fff',
             },
             colorSecondary: {
-                color: '#eaf075'
-            }
+                color: '#eaf075',
+            },
         },
     },
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,7 +64,7 @@ const IndexPage = () => {
     }, []);
 
     return (
-        <div className="About">
+        <div className="About FullPage">
             <Helmet>
                 <meta charSet="utf-8" />
                 <title>Armi's Portfolio</title>

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -7,11 +7,12 @@ import Paper from '@material-ui/core/Paper';
 import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 import CodeIcon from '@material-ui/icons/Code';
-import NavHeader from '../components/NavHeader';
-import Diagonals from '../components/Diagonals';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import anime from 'animejs';
+
+import NavHeader from '../components/NavHeader';
+import Diagonals from '../components/Diagonals';
 
 import projects from '../data/projects';
 
@@ -81,7 +82,7 @@ function Projects() {
     }, []);
 
     return (
-        <div className="Projects">
+        <div className="Projects full-page">
             <NavHeader />
             <Diagonals />
 

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -82,7 +82,7 @@ function Projects() {
     }, []);
 
     return (
-        <div className="Projects full-page">
+        <div className="Projects FullPage">
             <NavHeader />
             <Diagonals />
 

--- a/src/pages/work.tsx
+++ b/src/pages/work.tsx
@@ -6,6 +6,7 @@ import Paper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import anime from 'animejs';
+
 import NavHeader from '../components/NavHeader';
 import Diagonals from '../components/Diagonals';
 
@@ -117,7 +118,7 @@ const WorkPage = () => {
     }, []);
 
     return (
-        <div className="Work">
+        <div className="Work full-page">
             <NavHeader />
 
             <Diagonals />

--- a/src/pages/work.tsx
+++ b/src/pages/work.tsx
@@ -118,7 +118,7 @@ const WorkPage = () => {
     }, []);
 
     return (
-        <div className="Work full-page">
+        <div className="Work FullPage">
             <NavHeader />
 
             <Diagonals />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,7 +28,7 @@ div {
     }
 }
 
-/* TODO: Fix clipping */
+/* Parent of background needs to have position: relative */
 .background {
     overflow: hidden;
     height: 100%;
@@ -43,4 +43,8 @@ div {
     align-items: center;
 
     z-index: -1; /* Make background behind everything */
+}
+
+.full-papge {
+    position: relative;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,22 +29,18 @@ div {
 }
 
 /* Parent of background needs to have position: relative */
-.background {
+.Background {
     overflow: hidden;
     height: 100%;
     width: 100%;
     position: absolute;
-    float: left;
-    top: 0;
-    left: 0;
 
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    top: 0; /* Go under headers to not overflow*/
 
     z-index: -1; /* Make background behind everything */
 }
 
-.full-papge {
+.FullPage {
     position: relative;
+    min-height: 100vh;
 }


### PR DESCRIPTION
- Background element now anchors to parent correctly (`position: absolute` gets properties from first ancestor with non-static position)
- Diagonal lines now spawn in such a way that they will not go over the viewbox boundaries
- Classnames are all tile case now